### PR TITLE
bugfix; makes GBatchNorm centering and scaling optional

### DIFF
--- a/keras_gcnn/layers/normalization.py
+++ b/keras_gcnn/layers/normalization.py
@@ -82,8 +82,15 @@ class GBatchNorm(BatchNormalization):
                 K.tile(
                     K.expand_dims(w, -1), [1, n]), [-1])
 
-        self.repeated_gamma = repeat(self.gamma)
-        self.repeated_beta = repeat(self.beta)
+        if self.scale is True:
+            self.repeated_gamma = repeat(self.gamma)
+        else:
+            self.repeated_gamma = None
+
+        if self.center is True:
+            self.repeated_beta = repeat(self.beta)
+        else:
+            self.repeated_beta = None
 
         self.repeated_moving_mean = repeat(self.moving_mean)
         self.repeated_moving_variance = repeat(self.moving_variance)


### PR DESCRIPTION
Hi Bas,

This PR lets GBatchNorm make the affine transformation ( gamma * x + beta ) at the end optional.

This functionality is present in the current version of the function but the code as is tries to apply the repeat() function on None, leading to a crash.

Thanks for the great library for equivariant learning!

Best,
Neel